### PR TITLE
Add MonadFail instance for ListT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `list-transformer` v1.0.1
+# `list-transformer` v1.1.1
 
 This library provides a "`ListT` done right implementation" that obeys the
 `Monad` laws.

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 { mkDerivation, base, doctest, mtl, stdenv }:
 mkDerivation {
   pname = "list-transformer";
-  version = "1.0.1";
+  version = "1.1.1";
   src = ./.;
   libraryHaskellDepends = [ base mtl ];
   testHaskellDepends = [ base doctest ];

--- a/list-transformer.cabal
+++ b/list-transformer.cabal
@@ -1,5 +1,5 @@
 name:                list-transformer
-version:             1.0.1
+version:             1.1.1
 synopsis:            List monad transformer
 description:         This library provides a list monad transformer that
                      enriches lists with effects and streams efficiently in

--- a/src/List/Transformer.hs
+++ b/src/List/Transformer.hs
@@ -201,6 +201,9 @@ import Data.Traversable (Traversable)
 #endif
 import Control.Monad (MonadPlus(..))
 import Control.Monad.Error.Class (MonadError(..))
+#if MIN_VERSION_base(4,9,0)
+import Control.Monad.Fail (MonadFail(..))
+#endif
 import Control.Monad.State.Class (MonadState(..))
 import Control.Monad.Reader.Class (MonadReader(..))
 import Control.Monad.Trans (MonadTrans(..), MonadIO(..))
@@ -270,6 +273,8 @@ instance Monad m => Monad (ListT m) where
             Nil       -> return Nil
             Cons x l' -> next (k x <|> (l' >>= k)) )
 
+    fail _ = mzero
+
 instance Monad m => Alternative (ListT m) where
     empty = ListT (return Nil)
 
@@ -283,6 +288,11 @@ instance Monad m => MonadPlus (ListT m) where
     mzero = empty
 
     mplus = (<|>)
+
+#if MIN_VERSION_base(4,9,0)
+instance Monad m => MonadFail (ListT m) where
+    fail _ = mzero
+#endif
 
 instance (Monad m, Monoid a) => Monoid (ListT m a) where
     mempty  = pure mempty


### PR DESCRIPTION
Hey there Gabriel; Nice work on this lib! It fills a gap in the eco-system really nicely!

I've been having some fun trying to write a Regex Matcher using ListT to do the backtracking; it's been working pretty well so far!

I thought it would be nice to have a `MonadFail` instance so I could write:

```haskell
match :: Expr -> ListT (State RState) String
match (Atom c) = do
  (x:xs) <- use matchString
  if x == c
     then matchString .= xs >> return [x]
     else empty
```

Where if matchString was empty  `(x:xs) <- use matchString` would `fail` and the whole block would just be `empty`;

What do you think of that idea? So far as I can tell it follows the MonadFail laws:

```
Left zero: ∀ s f. fail s >>= f ≡ fail s.
Right zero: ∀ v s. v >> fail s ≡ fail s
```

Unfortunately this implementation doesn't seem to be working for me for some reason; it's still triggering a run-time error; am I missing something?

Cheers!