### PR TITLE
Fix typos in the mapM code samples of the tutorial

### DIFF
--- a/src/List/Transformer.hs
+++ b/src/List/Transformer.hs
@@ -139,7 +139,7 @@
 >     lift (f x)
 >
 > -- Alternatively, using MonadComprehensions:
-> mapM f x = [ r | x <- select xs, r <- lift (f x) ]
+> mapM f xs = [ r | x <- select xs, r <- lift (f x) ]
 
     ... or:
 
@@ -149,7 +149,7 @@
 >     lift (f x)
 >
 > -- Alternatively, using MonadComprehensions:
-> mapM f x = [ r | x <- xs, r <- lift (f x) ]
+> mapM f xs = [ r | x <- xs, r <- lift (f x) ]
 
     ... or:
 
@@ -159,7 +159,7 @@
 >     f x
 >
 > -- Alternatively, using MonadComprehensions:
-> mapM f x = [ r | x <- xs, r <- f x ]
+> mapM f xs = [ r | x <- xs, r <- f x ]
 >
 > -- Alternatively, using a pre-existing operator from "Control.Monad"
 > mapM = (=<<)


### PR DESCRIPTION
Minor typos in (the monad comprehension variants of) `mapM`, argument should be `xs` in each case.