### PR TITLE
"ZipListT", newtype wrapper for a zippy Applicative instance.

### DIFF
--- a/src/List/Transformer.hs
+++ b/src/List/Transformer.hs
@@ -574,24 +574,24 @@ instance Monad m => Functor (Step m) where
 -- >>> let xs = do x <- select [1,2,3,4]; liftIO (print x)
 -- >>> let ys = do y <- select [5,6]; liftIO (print y)
 -- >>> runListT (xs *> ys)
--- "1"
--- "5"
--- "6"
--- "2"
--- "5"
--- "6"
--- "3"
--- "5"
--- "6"
--- "4"
--- "5"
--- "6"
+-- 1
+-- 5
+-- 6
+-- 2
+-- 5
+-- 6
+-- 3
+-- 5
+-- 6
+-- 4
+-- 5
+-- 6
 -- >>> runListT (getZipListT (ZipListT xs *> ZipListT ys))
--- "1"
--- "4"
--- "2"
--- "5"
--- "3"
+-- 1
+-- 5
+-- 2
+-- 6
+-- 3
 --
 -- Note that the final "3" is printed even though it isn't paired with
 -- anything.


### PR DESCRIPTION
Not sure if this is within the scope or the vision of this library, but I've been using this separately in a few places.  It's small enough (basically three lines) that it's probably not *necessary* to have it as a part of the library, but just putting it here in case you think it might be useful to have it in a central place.