### PR TITLE
Add MFunctor instances for ListT and Step

### DIFF
--- a/list-transformer.cabal
+++ b/list-transformer.cabal
@@ -24,6 +24,7 @@ library
   default-language:    Haskell2010
   build-depends:       base >= 4.5 && < 5
                      , mtl >= 2.1 && < 2.3
+                     , mmorph >= 1.1.3 && < 1.3
   if !impl(ghc >= 8.0)
     build-depends:     semigroups == 0.18.*
   if !impl(ghc >= 8.0)


### PR DESCRIPTION
The lower bound of 1.1.3 on `mmorph` is the oldest version that I could test without going farther back in time than GHC 8.8.

Closes #25