### PR TITLE
Remove `MonadTrans` instance for `ZipListT`

### DIFF
--- a/src/List/Transformer.hs
+++ b/src/List/Transformer.hs
@@ -818,7 +818,7 @@ instance MFunctor Step where
 -- that expects "an Applicative instance", written to be polymorphic over
 -- all Applicatives.
 newtype ZipListT m a = ZipListT { getZipListT :: ListT m a }
-  deriving (Functor, Alternative, Foldable, Traversable, MonadTrans, Floating, Fractional, Num, Semigroup, Monoid)
+  deriving (Functor, Alternative, Foldable, Traversable, Floating, Fractional, Num, Semigroup, Monoid)
 
 instance Monad m => Applicative (ZipListT m) where
     pure x = ZipListT go


### PR DESCRIPTION
Fixes https://github.com/Gabriella439/list-transformer/issues/29

This instance is no longer possible for newer versions of `transformers` because the `MonadTrans` instance would now require an `instance Monad m => Monad (ZipListT m)` which is not possible to implement.